### PR TITLE
subscriptions#unsubscribe should be shown as a member route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ configuration needs to be applied in the
 
     ```Ruby
     # bad
-    get 'subscriptions/unsubscribe'
-    resources 'subscription'
+    get 'subscriptions/:id/unsubscribe'
+    resources :subscriptions
 
     # good
     resources :subscriptions do


### PR DESCRIPTION
To avoid confusion, subscriptions#unsubscribe should be a member route, not a collection route here, i.e.

```
# bad
get 'subscriptions/:id/unsubscribe'
resources :subscriptions
```

instead of:

```
# bad
get 'subscriptions/unsubscribe' # this would be a collection route
resources :subscriptions
```
