### PR TITLE
fixing a small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ your application.
     config.action_mailer.delivery_method = :test
     ```
 
-* The delivery methods for development and production should be `smtp`:
+* The delivery method for development and production should be `smtp`:
 
     ```Ruby
     # config/environments/development.rb, config/environments/production.rb


### PR DESCRIPTION
Great guide.  I found a small typo and corrected it: "methos" -> "methods"
