### PR TITLE
Explain difference between Capybara's negative matchers and should_not

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,9 @@ can be one steps file for all features for a particular object
       }
     end
     ```
+* Always use the Capybara negative matchers instead of should_not with positive,
+they will retry the match for given timeout allowing you to test ajax actions.
+[See Capybara's README for more explanation](https://github.com/jnicklas/capybara)
 
 <a name="rspec"/>
 ## RSpec


### PR DESCRIPTION
I have added an explanation why you should use Capybara's matchers in the acceptance tests.

But why you should prefer to use the capybara matchers in the view tests ?

They wait for a given timeout before returning false and this make ajax/javascript actions possible to test, but I think in the view test you don't need that.
I was going to change the "prefer" to "always", but I don't see why you should do it, maybe only for consistency with the acceptance ones.

Don't you have duplication in the acceptance and view tests ? The view is simple template and you will test the behavior in the acceptance test anyway, everything else that need unit testing will be in helpers and modules, so I don't see the value in testing the views.
