### PR TITLE
Use preferred `#[]` to `#read_attribute` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ the same purpose of the named scope and returns and
 
     ```Ruby
     def amount
-      read_attribute(:amount) or 0
+      self[:amount] or 0
     end
     ```
 


### PR DESCRIPTION
I've never seen anyone use `read_attribute`. People generally use `[]` to access the underlying attribute for a model.
