### PR TITLE
Remove invalid advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,10 +1022,6 @@ can be one steps file for all features for a particular object
     end
     ```
 
-* Always use the Capybara negative matchers instead of should_not with positive,
-they will retry the match for given timeout allowing you to test ajax actions.
-[See Capybara's README for more explanation](https://github.com/jnicklas/capybara)
-
 ## RSpec
 
 * Use just one expectation per example.


### PR DESCRIPTION
Capybara's Readme clearly says:

```
The two following statements are functionally equivalent:

page.should_not have_xpath('a')
page.should have_no_xpath('a')
```

Both of them do not wait if there is no element since [Capybara overrides `does_not_match?` too](https://github.com/jnicklas/capybara/blob/master/lib/capybara/rspec/matchers.rb#L22)
