### PR TITLE
added Mailcatcher as example for local SMTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,14 +563,14 @@ your application.
     config.action_mailer.raise_delivery_errors = true
     ```
 
-* Use `smtp.gmail.com` for SMTP server in the development environment
-  (unless you have local SMTP server, of course).
+* Use a local SMTP server like [Mailcatcher](https://github.com/sj26/mailcatcher) in the development environment.
 
     ```Ruby
     # config/environments/development.rb
 
     config.action_mailer.smtp_settings = {
-      address: 'smtp.gmail.com',
+      address: 'localhost',
+      port: 1025,
       # more settings
     }
     ```


### PR DESCRIPTION
Mailcatcher is a nice gem to setup a local SMTP server for (internal) display of generated mails through a web interface. Using smtp.gmail.com or any other external service should be the last resort and almost never be considered as 'good style'.
