### PR TITLE
Avoid `ActiveRecord::Base.suppress`

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,18 @@ render status: :forbidden
     has_many :comments, dependent: :destroy
   end
   ```
+* <a name="avoid-suppress"></a>
+  Avoid `ActiveRecord::Base.suppress` (Rails 5).
+<sup>[[link](#avoid-suppress)]</sup>
+
+  ```Ruby
+  # bad
+  def foo
+    Notification.suppress do
+      # Behaviour that should not trigger notifications
+    end
+  end
+  ```
 
 ### ActiveRecord Queries
 


### PR DESCRIPTION
There is strong opposition to this in the Rails community:

https://www.reddit.com/r/ruby/comments/4j3097/rails_5_activerecord_suppress_a_step_too_far/
https://medium.com/spritle-software/rails-5-activerecord-suppress-a-step-too-far-d7ec2e4ed027#.lmh6aycc6
https://twitter.com/search?q=rails%20suppress
