### PR TITLE
Match good and bad examples for status code guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ render plain: 'Ruby!'
 ```Ruby
 # bad
 ...
-render status: 500
+render status: 403
 ...
 
 # good


### PR DESCRIPTION
When giving good/bad examples about the guideline for using status code symbols instead of numeric values, give a good and a bad example with the same status code.
