### PR TITLE
Add section about String#to_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1463,8 +1463,8 @@ pets.include? 'cat'
 <sup>[[link](#to-time)]</sup>
 
   ```ruby
-  # bad
-  '2015-03-02 19:05:37'.to_time # => Will also assume time string given is in the system's time zone.
+  # bad - assumes time string given is in the system's time zone.
+  '2015-03-02 19:05:37'.to_time
 
   # good
   Time.zone.parse('2015-03-02 19:05:37') # => Mon, 02 Mar 2015 19:05:37 EET +02:00

--- a/README.md
+++ b/README.md
@@ -1458,6 +1458,18 @@ pets.include? 'cat'
   Time.zone.parse('2015-03-02 19:05:37') # => Mon, 02 Mar 2015 19:05:37 EET +02:00
   ```
 
+* <a name="to-time"></a>
+  Don't use [`String#to_time`](https://apidock.com/rails/String/to_time)
+<sup>[[link](#to-time)]</sup>
+
+  ```ruby
+  # bad
+  '2015-03-02 19:05:37'.to_time # => Will also assume time string given is in the system's time zone.
+
+  # good
+  Time.zone.parse('2015-03-02 19:05:37') # => Mon, 02 Mar 2015 19:05:37 EET +02:00
+  ```
+
 * <a name="time-now"></a>
   Don't use `Time.now`.
 <sup>[[link](#time-now)]</sup>


### PR DESCRIPTION
As I reported in #233, `String#to_time` has the same behaviour as `Time.parse` and hence probably should also be considered bad style.