### PR TITLE
Use "find(id)" instead of "find_by(id: id)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ render status: :forbidden
     User.find_by_first_name_and_last_name('Bruce', 'Wayne')
 
     # good
-    User.find(id)
+    User.find_by(email: email)
     User.find_by(first_name: 'Bruce', last_name: 'Wayne')
     ```
 

--- a/README.md
+++ b/README.md
@@ -834,11 +834,11 @@ render status: :forbidden
 
     ```ruby
     # bad
-    User.where(id: id).take
+    User.where(email: email).take
     User.where(first_name: 'Bruce', last_name: 'Wayne').take
 
     # bad
-    User.find_by_id(id)
+    User.find_by_email(email)
     # bad, deprecated in ActiveRecord 4.0, removed in 4.1+
     User.find_by_first_name_and_last_name('Bruce', 'Wayne')
 

--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ render status: :forbidden
     User.find_by_first_name_and_last_name('Bruce', 'Wayne')
 
     # good
-    User.find_by(id: id)
+    User.find(id)
     User.find_by(first_name: 'Bruce', last_name: 'Wayne')
     ```
 


### PR DESCRIPTION
"find_by(id: id)" was used as good practice