### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ render status: :forbidden
 
   * <a name="callbacks-order"></a>
     Order callback declarations in the order, in which they will be executed. For
-    referenece, see [Available Callbacks](https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks)
+    reference, see [Available Callbacks](https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks)
     <sup>[[link](#callbacks-order)]</sup>
 
     ```Ruby


### PR DESCRIPTION
This PR fixes a typo using misspell.
https://github.com/client9/misspell

```console
% misspell -w .
README.md:575:4: corrected "referenece" to "reference"
```