### PR TITLE
Remove an incorrect comment for `find_by` example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -831,7 +831,6 @@ User.where(first_name: 'Bruce', last_name: 'Wayne').take
 
 # bad
 User.find_by_email(email)
-# bad, deprecated in Active Record 4.0, removed in 4.1+
 User.find_by_first_name_and_last_name('Bruce', 'Wayne')
 
 # good


### PR DESCRIPTION
Dynamic finder methods (`DynamicMatchers`)  has not been previously deprecated.
AFAIK, next release Rails 6.0 has also no plans to deprecate it.
https://github.com/rails/rails/blob/v6.0.0.rc1/activerecord/lib/active_record/dynamic_matchers.rb

So, it seems that this was written incorrectly when I refer to the following.

- https://github.com/rubocop-hq/rails-style-guide/pull/220
- https://github.com/rubocop-hq/rails-style-guide/issues/208

Therefore this PR removes the incorrect example comment for `find_by`.