### PR TITLE
Changed example enum

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -424,7 +424,7 @@ class User < ActiveRecord::Base
   attr_accessible :login, :first_name, :last_name, :email, :password
 
   # Rails 4+ enums after attr macros
-  enum gender: { female: 0, male: 1 }
+  enum role: { user: 0, moderator: 1, admin: 2 }
 
   # followed by association macros
   belongs_to :country


### PR DESCRIPTION
I think gender isn't a good example for a specifically limited set of valid options. Changing it to a user role example both communicates the intended message and isn't exclusionary.