### PR TITLE
In durations, make sure method usage reads as plain english

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1539,7 +1539,7 @@ If used without a parameter, prefer `from_now` and `ago` instead of `since`, `af
 
 [source,ruby]
 ----
-# bad - It's not clear at first sight that the qualifier refers to the current time (which is the default parameter)
+# bad - It's not clear that the qualifier refers to the current time (which is the default parameter)
 5.hours.since
 5.hours.after
 5.hours.before
@@ -1565,7 +1565,7 @@ If used with a parameter, prefer `since`, `after`, `until` or `before` instead o
 2.days.until(yesterday)
 ----
 
-Avoid using literal negative numbers for the duration subject. Always prefer using a qualifier that allows using positive literal numbers.
+Avoid using negative numbers for the duration subject. Always prefer using a qualifier that allows using positive literal numbers.
 
 [source,ruby]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -1535,20 +1535,39 @@ Time.current # Same thing but shorter.
 
 == Duration
 
-=== `.since` [[duration-since]]
-
-Don't use `.since` without a parameter, prefer `.from_now`.
+Don't use `.since`, `.after` without a parameter, prefer `.from_now`.
+Dont't use `.until`, `.before`, without a parameter, prefer `ago`.
+Dont't use `.ago' or `.from_now` with a parameter, prefer their respective aliases `.until` or `.before` for `ago` and `.since` or `.after` for `from_now`
+Don't use hard coded negative numbers for the duration subject
+As a general rule, make sure that reading the code as it was plain english makes total sense.
 
 [source,ruby]
 ----
 # bad
 5.hours.since # => It's not clear at first sight that `since` refers to "since now" 
+5.hours.after # => It's not clear at first sight that `after` refers to "after now"
+5.hours.before # => It's not clear at first sight that `before` refers to "before now" 
+5.hours.until # => It's not clear at first sight that `until` refers to "until now"
 
+tomorrow = 2.days.from_now(yesterday) # yesterday would be 1.day.ago, reading this is confusing 
+today = 1.day.ago(tomorrow)
+
+
+-5.hours.from_now # reading this is confusing
+-5.hours.ago # reading this is confusing
+-5.hours.after(today)
 # good
 5.hours.from_now # when refering a future time from now, use from_now
+5.hours.ago # when refering a past time from now, use ago
 
-yesterday = 1.day.ago
 tomorrow = 2.days.since(yesterday) # use since only when you have a referential Time in the past
+tomorrow = 2.days.after(yesterday) # use after only when you have a referential Time in the past
+today = 1.day.before(tomorrow) # use before only when you have a referential Time in the future
+today = 1.day.until(tomorrow) # use until only when you have a referential Time in the future
+
+5.hours.ago # use the inverse method instead of the inverse number, -5.hours.from_now becomes 5.hours.ago
+5.hours.ago # use the inverse method instead of the inverse number, -5.hours.ago becomes 5.hours.ago
+5.hours.before(today)
 ----
 
 == Bundler

--- a/README.adoc
+++ b/README.adoc
@@ -1535,43 +1535,47 @@ Time.current # Same thing but shorter.
 
 == Duration
 
-Don't use `.since`, `.after` without a parameter, prefer `.from_now`.
-
-Dont't use `.until`, `.before`, without a parameter, prefer `ago`.
-
-Dont't use `.ago' or `.from_now` with a parameter, prefer their respective aliases `.until` or `.before` for `ago` and `.since` or `.after` for `from_now`
-
-Don't use hard coded negative numbers for the duration subject
-
-As a general rule, make sure that reading the code as it was plain english makes total sense.
+If used without a parameter, prefer `from_now` and `ago` instead of `since`, `after`, `until` or `before`.
 
 [source,ruby]
 ----
-# bad
-5.hours.since # => It's not clear at first sight that `since` refers to "since now" 
-5.hours.after # => It's not clear at first sight that `after` refers to "after now"
-5.hours.before # => It's not clear at first sight that `before` refers to "before now" 
-5.hours.until # => It's not clear at first sight that `until` refers to "until now"
+# bad - It's not clear at first sight that the qualifier refers to the current time (which is the default parameter)
+5.hours.since
+5.hours.after
+5.hours.before
+5.hours.until
 
-tomorrow = 2.days.from_now(yesterday) # yesterday would be 1.day.ago, reading this is confusing 
-today = 1.day.ago(tomorrow)
-
-
--5.hours.from_now # reading this is confusing
--5.hours.ago # reading this is confusing
--5.hours.after(today)
 # good
-5.hours.from_now # when refering a future time from now, use from_now
-5.hours.ago # when refering a past time from now, use ago
+5.hours.from_now
+5.hours.ago
+----
 
-tomorrow = 2.days.since(yesterday) # use since only when you have a referential Time in the past
-tomorrow = 2.days.after(yesterday) # use after only when you have a referential Time in the past
-today = 1.day.before(tomorrow) # use before only when you have a referential Time in the future
-today = 1.day.until(tomorrow) # use until only when you have a referential Time in the future
+If used with a parameter, prefer `since`, `after`, `until` or `before` instead of `from_now` and `ago`.
 
-5.hours.ago # use the inverse method instead of the inverse number, -5.hours.from_now becomes 5.hours.ago
-5.hours.ago # use the inverse method instead of the inverse number, -5.hours.ago becomes 5.hours.ago
-5.hours.before(today)
+[source,ruby]
+----
+# bad - It's confusing and misleading to read
+2.days.from_now(yesterday)
+2.days.ago(yesterday)
+
+# good
+2.days.since(yesterday)
+2.days.after(yesterday)
+2.days.before(yesterday)
+2.days.until(yesterday)
+----
+
+Avoid using literal negative numbers for the duration subject. Always prefer using a qualifier that allows using positive literal numbers.
+
+[source,ruby]
+----
+# bad - It's confusing and misleading to read
+-5.hours.from_now
+-5.hours.ago
+
+# good
+5.hours.ago
+5.hours.from_now
 ----
 
 == Bundler

--- a/README.adoc
+++ b/README.adoc
@@ -1536,9 +1536,13 @@ Time.current # Same thing but shorter.
 == Duration
 
 Don't use `.since`, `.after` without a parameter, prefer `.from_now`.
+
 Dont't use `.until`, `.before`, without a parameter, prefer `ago`.
+
 Dont't use `.ago' or `.from_now` with a parameter, prefer their respective aliases `.until` or `.before` for `ago` and `.since` or `.after` for `from_now`
+
 Don't use hard coded negative numbers for the duration subject
+
 As a general rule, make sure that reading the code as it was plain english makes total sense.
 
 [source,ruby]

--- a/README.adoc
+++ b/README.adoc
@@ -1533,6 +1533,24 @@ Time.zone.now # => Fri, 12 Mar 2014 22:04:47 EET +02:00
 Time.current # Same thing but shorter.
 ----
 
+== Duration
+
+=== `.since` [[duration-since]]
+
+Don't use `.since` without a parameter, prefer `.from_now`.
+
+[source,ruby]
+----
+# bad
+5.hours.since # => It's not clear at first sight that `since` refers to "since now" 
+
+# good
+5.hours.from_now # when refering a future time from now, use from_now
+
+yesterday = 1.day.ago
+tomorrow = 2.days.since(yesterday) # use since only when you have a referential Time in the past
+----
+
 == Bundler
 
 === Dev/Test Gems [[dev-test-gems]]


### PR DESCRIPTION
related to rubocop-hq/rubocop-rails#340

When you read:

```ruby
in_5_hours = 5.hours.from_now
```

it is easy to understand that it is a time that will happen in 5 hours from this moment.

In the other hand, 

```ruby
in_5_hours = 5.hours.since 
```

when you read it, you ask yourself, "since what?" I had to go to the method definition and find out that `since` receives a parameter that defaults to `::Time.current`, thats not evident at first sight.

we should encourage the usage of `.from_now` instead of `.since` without parameter

Using a `since` with a parameter is totally fine though

```ruby
yesterday = 1.day.ago
tomorrow = 2.days.since(yesterday)
```

