### PR TITLE
Tweak find-by-memoization good example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1160,11 +1160,9 @@ end
 
 # good
 def current_user
-  if instance_variable_defined?(:@current_user)
-    @current_user
-  else
-    @current_user = User.find_by(id: session[:user_id])
-  end
+  return @current_user if defined?(@current_user)
+
+  @current_user = User.find_by(id: session[:user_id])
 end
 ----
 


### PR DESCRIPTION
The current good section is quite a mouthful.
That is partially the fault of Ruby, but it can be better:
* Less indentation
* Fewer lines with code on them
* More concise

This style is quite common:
https://github.com/search?q=lang%3Aruby%20%2Freturn%20.*%20if%20defined%2F&type=code

Tried searching for the other one but every search I try just times out.

As for `instance_variable_defined?` vs `defined?`, it's just shorter but does the same thing.

I would like to change rubocop-rails autocorrect for this, so opening here first. https://github.com/rubocop/rubocop-rails/issues/1513

cc @r7kamura if you have opinions here.