### PR TITLE
Avoid `Kernel.suppress(Exception)`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1768,6 +1768,23 @@ datetime.to_fs(:db)
 42.to_fs(:human)
 ----
 
+=== Do not rescue `Exception` via `Kernel.suppress` [[kernel-suppress-exception]
+
+Using `Kernel.suppress(Exception)` is effectively equivalent to rescuing `Exception`, which is discouraged.
+
+[source,ruby]
+----
+# bad
+suppress(Exception) do
+  do_something
+end
+
+# good
+supress(StandardError) do
+  do_something
+end
+----
+
 == Time
 
 === Time Zone Config [[tz-config]]


### PR DESCRIPTION
ref: https://github.com/rubocop/rubocop-rails/issues/1547

https://api.rubyonrails.org/classes/Kernel.html#method-i-suppress

Using `Kernel.suppress(Exception) { ?? }` is effectively equivalent to:

```ruby
begin
  ??
rescue Exception
end
```

Since rescuing `Exception` directly is discouraged by `Lint/RescueException`, it makes sense to discourage this usage as well.